### PR TITLE
Allow for errors to be strings

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -136,7 +136,10 @@ class Log extends EventEmitter {
             .try(() => {
               let error = undefined;
 
-              if (err) {
+              if (_.isString(err)) {
+                error = { message: err };
+              }
+              else if (err) {
                 let { name, message, stack } = err;
                 let filtered_err = _.pickBy({ name, message, stack }, _.identity);
                 error = { ...filtered_err, ..._.omit(err, ['name', 'message', 'stack']) };


### PR DESCRIPTION
Allow for errors to be strings instead of error objects. The problem is if err is a string, error object ends up being this massive object where each character in the string is a property, thanks to ..._.omit line.