### PR TITLE
Fix log pipe in case of bad exit code

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -93,12 +93,15 @@ class Log extends EventEmitter {
               if (code) {
                 let err = new Error(`process exited with code ${code}`);
                 err.code = code;
-
-                if (end) {
-                  this.end(err, undefined);
-                }
-                  
-                throw err;
+                return Promise
+                        .try(() => {
+                          if (end) {
+                            return this.end(err, undefined);
+                          }
+                        })
+                        .then(() => {
+                          throw err;
+                        });
               }
 
               if (end) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -87,18 +87,22 @@ class Log extends EventEmitter {
     return Promise
             .all(arr)
             .then((result) => result[0])
-            .tap((output) => {
-              if (end) {
-                return this.end(undefined, output);
-              }
-            })
             .tap((output = {}) => {
               let { code } = output;
 
               if (code) {
                 let err = new Error(`process exited with code ${code}`);
                 err.code = code;
+
+                if (end) {
+                  this.end(err, undefined);
+                }
+                  
                 throw err;
+              }
+
+              if (end) {
+                return this.end(undefined, output);
               }
             })
             .asCallback(cb);


### PR DESCRIPTION
The bad scenario is when end = true, and process exit code <> 0.

Current:
We prematurely end the log with success.

Expected:
End the log with error indicating bad exit code.

