### PR TITLE
Close socket

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -162,16 +162,7 @@ class Log extends EventEmitter {
             })
             .delay(15 * 1000)
             .tap(() => {
-              let p = this.producer.cache.get();
-              if (p) {
-                return p
-                        .socket()
-                        .then((socket) => {
-                          if (!_.isNil(socket)) {
-                            socket.close();
-                          }
-                        });
-              }
+              return this.close_socket();
             });
   }
 
@@ -207,6 +198,22 @@ class Log extends EventEmitter {
 
   toString() {
     return this.stringify();
+  }
+
+  close_socket() {
+    return Promise
+     .try(() => {
+       let p = this.producer.cache.get();
+       if (p) {
+         return p
+                .socket()
+                .then((socket) => {
+                  if (!_.isNil(socket)) {
+                    socket.close();
+                  }
+                });
+       }
+     });
   }
 
   static open(options = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailf.io-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailf.io-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The problem arises when we have a producer and consumer as two different node processes. It results in a socket leak, that never gets released until the consumer restarts its node process.

Scenario:
Consumer creates the log.
Producer does the work through pipe. End the log.
Consumer never closes its socket, because it never explicitly called end.

Solution:
We need to extract close socket out of end. And have the consumer "dispose" cleanly after it's done with log.

